### PR TITLE
Minor fixes for page descriptor and EOF trailing

### DIFF
--- a/src/helpers/plainAddPlaceholder/getPagesDictionaryRef.js
+++ b/src/helpers/plainAddPlaceholder/getPagesDictionaryRef.js
@@ -5,7 +5,7 @@ import SignPdfError from '../../SignPdfError';
  */
 
 export default function getPagesDictionaryRef(info) {
-    const pagesRefRegex = new RegExp('\\/Type\\s*\\/Catalog\\s*\\/Pages\\s+(\\d+\\s\\d+\\sR)', 'g');
+    const pagesRefRegex = new RegExp('\\/Pages\\s+(\\d+\\s+\\d+\\s+R)', 'g');
     const match = pagesRefRegex.exec(info.root);
     if (match === null) {
         throw new SignPdfError(

--- a/src/helpers/plainAddPlaceholder/getPagesDictionaryRef.test.js
+++ b/src/helpers/plainAddPlaceholder/getPagesDictionaryRef.test.js
@@ -16,4 +16,22 @@ describe('getPagesDictionaryRef', () => {
             expect(e.message).toMatchSnapshot();
         }
     });
+
+    it('getPagesDictionaryRef gets pages descriptor', () => {
+        const info = {
+            root: '/Type /Catalog\n/Pages 14 0 R',
+        };
+
+        const pagesRef = getPagesDictionaryRef(info);
+        expect(pagesRef).toBe("14 0 R")
+    });
+
+    it('getPagesDictionaryRef gets pages descriptor when info root is in another order', () => {
+        const info = {
+            root: '/Pages 2 0 R /Type/Catalog/ViewerPreferences<</DisplayDocTitle true/HideMenubar true/HideToolbar true/HideWindowUI true>>',
+        };
+
+        const pagesRef = getPagesDictionaryRef(info);
+        expect(pagesRef).toBe("2 0 R")
+    }); 
 });

--- a/src/helpers/removeTrailingNewLine.js
+++ b/src/helpers/removeTrailingNewLine.js
@@ -1,5 +1,14 @@
 import SignPdfError from '../SignPdfError';
 
+const sliceLastChar = (pdf, character) => {
+    const lastChar = pdf.slice(pdf.length - 1).toString();
+    if (lastChar === character) {
+        return pdf.slice(0, pdf.length - 1);
+    }
+
+    return pdf;
+};
+
 /**
  * Removes a trailing new line if there is such.
  *
@@ -14,13 +23,10 @@ const removeTrailingNewLine = (pdf) => {
             SignPdfError.TYPE_INPUT,
         );
     }
-
-    const lastChar = pdf.slice(pdf.length - 1).toString();
     let output = pdf;
-    if (lastChar === '\n') {
-        // remove the trailing new line
-        output = pdf.slice(0, pdf.length - 1);
-    }
+
+    output = sliceLastChar(output, '\n');
+    output = sliceLastChar(output, '\r');
 
     const lastLine = output.slice(output.length - 6).toString();
     if (lastLine !== '\n%%EOF') {

--- a/src/helpers/removeTrailingNewLine.test.js
+++ b/src/helpers/removeTrailingNewLine.test.js
@@ -31,4 +31,9 @@ describe('removeTrailingNewLine', () => {
         const result = removeTrailingNewLine(source);
         expect(result.toString()).toEqual('something with a new line\n%%EOF');
     });
+    it('removes a trailing new line with carriage return', () => {
+        const source = Buffer.from('something with a new line\r\n%%EOF\r\n');
+        const result = removeTrailingNewLine(source);
+        expect(result.toString()).toEqual('something with a new line\r\n%%EOF');
+    });
 });


### PR DESCRIPTION
Two minor bugfixes for Windows generated PDFs.

- Fixes removeTrailingNewLine to also remove carriage return
- Simplifies regex that finds page dictionary ref