### PR TITLE
allow pdfkitAddPlaceholder to receive custom location, contactInfo, name

### DIFF
--- a/src/helpers/__snapshots__/pdfkitAddPlaceholder.test.js.snap
+++ b/src/helpers/__snapshots__/pdfkitAddPlaceholder.test.js.snap
@@ -7,3 +7,19 @@ Array [
   "widget",
 ]
 `;
+
+exports[`pdfkitAddPlaceholder placeholder contains default values for contactInfo, name, location 1`] = `
+Array [
+  "signature",
+  "form",
+  "widget",
+]
+`;
+
+exports[`pdfkitAddPlaceholder placeholder contains reason, contactInfo, name, location 1`] = `
+Array [
+  "signature",
+  "form",
+  "widget",
+]
+`;

--- a/src/helpers/pdfkitAddPlaceholder.js
+++ b/src/helpers/pdfkitAddPlaceholder.js
@@ -34,9 +34,9 @@ const pdfkitAddPlaceholder = ({
         Contents: Buffer.from(String.fromCharCode(0).repeat(signatureLength)),
         Reason: new String(reason), // eslint-disable-line no-new-wrappers
         M: new Date(),
-        ContactInfo: contactInfo, // eslint-disable-line no-new-wrappers
-        Name: name, // eslint-disable-line no-new-wrappers
-        Location: location, // eslint-disable-line no-new-wrappers
+        ContactInfo: new String(contactInfo), // eslint-disable-line no-new-wrappers
+        Name: new String(name), // eslint-disable-line no-new-wrappers
+        Location: new String(location), // eslint-disable-line no-new-wrappers
     });
 
     // Check if pdf already contains acroform field

--- a/src/helpers/pdfkitAddPlaceholder.js
+++ b/src/helpers/pdfkitAddPlaceholder.js
@@ -13,6 +13,9 @@ const pdfkitAddPlaceholder = ({
     pdf,
     pdfBuffer,
     reason,
+    contactInfo = 'emailfromp1289@gmail.com',
+    name = 'Name from p12',
+    location = 'Location from p12',
     signatureLength = DEFAULT_SIGNATURE_LENGTH,
     byteRangePlaceholder = DEFAULT_BYTE_RANGE_PLACEHOLDER,
 }) => {
@@ -31,9 +34,9 @@ const pdfkitAddPlaceholder = ({
         Contents: Buffer.from(String.fromCharCode(0).repeat(signatureLength)),
         Reason: new String(reason), // eslint-disable-line no-new-wrappers
         M: new Date(),
-        ContactInfo: new String('emailfromp1289@gmail.com'), // eslint-disable-line no-new-wrappers
-        Name: new String('Name from p12'), // eslint-disable-line no-new-wrappers
-        Location: new String('Location from p12'), // eslint-disable-line no-new-wrappers
+        ContactInfo: contactInfo, // eslint-disable-line no-new-wrappers
+        Name: name, // eslint-disable-line no-new-wrappers
+        Location: location, // eslint-disable-line no-new-wrappers
     });
 
     // Check if pdf already contains acroform field

--- a/src/helpers/pdfkitAddPlaceholder.test.js
+++ b/src/helpers/pdfkitAddPlaceholder.test.js
@@ -22,4 +22,55 @@ describe('pdfkitAddPlaceholder', () => {
             '**********',
         ]);
     });
+
+    it('placeholder contains reason, contactInfo, name, location', () => {
+        const pdf = new PDFDocument({
+            autoFirstPage: true,
+            size: 'A4',
+            layout: 'portrait',
+            bufferPages: true,
+        });
+        pdf.info.CreationDate = '';
+
+        const refs = pdfkitAddPlaceholder({
+            pdf,
+            pdfBuffer: Buffer.from([pdf]),
+            reason: 'test reason',
+            contactInfo :'testemail@test.com',
+            name :'test name',
+            location : 'test Location'
+        });
+        expect(Object.keys(refs)).toMatchSnapshot();
+        expect(pdf.page.dictionary.data.Annots).toHaveLength(1);
+        expect(pdf.page.dictionary.data.Annots[0].data.Subtype).toEqual('Widget');
+        let widgetData = pdf.page.dictionary.data.Annots[0].data.V.data;
+        expect(widgetData['Reason']).toEqual('test reason')
+        expect(widgetData['ContactInfo']).toEqual('testemail@test.com')
+        expect(widgetData['Name']).toEqual('test name')
+        expect(widgetData['Location']).toEqual('test Location')
+    });
+
+    it('placeholder contains default values for contactInfo, name, location', () => {
+        const pdf = new PDFDocument({
+            autoFirstPage: true,
+            size: 'A4',
+            layout: 'portrait',
+            bufferPages: true,
+        });
+        pdf.info.CreationDate = '';
+
+        const refs = pdfkitAddPlaceholder({
+            pdf,
+            pdfBuffer: Buffer.from([pdf]),
+            reason: 'test reason'
+        });
+        expect(Object.keys(refs)).toMatchSnapshot();
+        expect(pdf.page.dictionary.data.Annots).toHaveLength(1);
+        expect(pdf.page.dictionary.data.Annots[0].data.Subtype).toEqual('Widget');
+        let widgetData = pdf.page.dictionary.data.Annots[0].data.V.data;
+        expect(widgetData['Reason']).toEqual('test reason')
+        expect(widgetData['ContactInfo']).toEqual('emailfromp1289@gmail.com')
+        expect(widgetData['Name']).toEqual('Name from p12')
+        expect(widgetData['Location']).toEqual('Location from p12')
+    });
 });

--- a/src/helpers/plainAddPlaceholder/index.js
+++ b/src/helpers/plainAddPlaceholder/index.js
@@ -30,6 +30,9 @@ const isContainBufferRootWithAcroform = (pdf) => {
 const plainAddPlaceholder = ({
     pdfBuffer,
     reason,
+    contactInfo = 'emailfromp1289@gmail.com',
+    name = 'Name from p12',
+    location = 'Location from p12',
     signatureLength = DEFAULT_SIGNATURE_LENGTH,
 }) => {
     let pdf = removeTrailingNewLine(pdfBuffer);
@@ -77,6 +80,9 @@ const plainAddPlaceholder = ({
         pdf: pdfKitMock,
         pdfBuffer,
         reason,
+        contactInfo,
+        name,
+        location,
         signatureLength,
     });
 

--- a/src/helpers/plainAddPlaceholder/index.test.js
+++ b/src/helpers/plainAddPlaceholder/index.test.js
@@ -5,7 +5,13 @@ describe('plainAddPlaceholder', () => {
     it('adds placeholder to a prepared document', () => {
         const input = fs.readFileSync(`${__dirname}/../../../resources/w3dummy.pdf`);
         expect(input.indexOf('/ByteRange')).toBe(-1);
-        const output = plainAddPlaceholder({pdfBuffer: input, reason: 'Because I can'});
+        const output = plainAddPlaceholder({
+            pdfBuffer: input,
+            reason: 'Because I can',
+            location: 'some place',
+            name: 'example name',
+            contactInfo: 'emailfromp1289@gmail.com'
+        });
         expect(output).toBeInstanceOf(Buffer);
         expect(output.indexOf('/ByteRange')).not.toBe(-1);
     });

--- a/src/signpdf.test.js
+++ b/src/signpdf.test.js
@@ -168,6 +168,7 @@ describe('Test signing', () => {
         signedPdfBuffer = plainAddPlaceholder({
             pdfBuffer: signedPdfBuffer,
             reason: 'second',
+            location: 'test location',
             signatureLength: 1592,
         });
         signedPdfBuffer = signer.sign(signedPdfBuffer, secondP12Buffer, {passphrase: 'node-signpdf'});
@@ -181,6 +182,7 @@ describe('Test signing', () => {
         pdfBuffer = plainAddPlaceholder({
             pdfBuffer,
             reason: 'I have reviewed it.',
+            location: 'some city',
             signatureLength: 1612,
         });
         pdfBuffer = signer.sign(pdfBuffer, p12Buffer);


### PR DESCRIPTION
currently `pdfkitAddPlaceholder` API allows to customise only `reason` field for generated signature. 

Makes sense to extend it so we could have chance to set also `contactInfo `, `name`, `location` fields of signature. Changes are backward compatible so users do not need to explicitly pass these values if they do not wish to do it. 