### PR TITLE
🐛 Fixing AcroForm ID extraction

### DIFF
--- a/dist/helpers/pdfkitAddPlaceholder.js
+++ b/dist/helpers/pdfkitAddPlaceholder.js
@@ -25,6 +25,9 @@ const pdfkitAddPlaceholder = ({
   pdf,
   pdfBuffer,
   reason,
+  contactInfo = 'emailfromp1289@gmail.com',
+  name = 'Name from p12',
+  location = 'Location from p12',
   signatureLength = _const.DEFAULT_SIGNATURE_LENGTH,
   byteRangePlaceholder = _const.DEFAULT_BYTE_RANGE_PLACEHOLDER
 }) => {
@@ -39,11 +42,11 @@ const pdfkitAddPlaceholder = ({
     Reason: new String(reason),
     // eslint-disable-line no-new-wrappers
     M: new Date(),
-    ContactInfo: new String('emailfromp1289@gmail.com'),
+    ContactInfo: new String(contactInfo),
     // eslint-disable-line no-new-wrappers
-    Name: new String('Name from p12'),
+    Name: new String(name),
     // eslint-disable-line no-new-wrappers
-    Location: new String('Location from p12') // eslint-disable-line no-new-wrappers
+    Location: new String(location) // eslint-disable-line no-new-wrappers
 
   }); // Check if pdf already contains acroform field
 
@@ -53,10 +56,29 @@ const pdfkitAddPlaceholder = ({
   let acroFormId;
 
   if (isAcroFormExists) {
-    const pdfSlice = pdfBuffer.slice(acroFormPosition - 12);
+    let acroFormStart = acroFormPosition; // 10 is the distance between "/Type /AcroForm" and AcroFrom ID
+
+    const charsUntilIdEnd = 10;
+    const acroFormIdEnd = acroFormPosition - charsUntilIdEnd; // Let's find AcroForm ID by trying to find the "\n" before the ID
+    // 12 is a enough space to find the "\n" (generally it's 2 or 3, but I'm giving a big space though)
+
+    const maxAcroFormIdLength = 12;
+    let foundAcroFormId = '';
+
+    for (let index = charsUntilIdEnd + 1; index < charsUntilIdEnd + maxAcroFormIdLength; index++) {
+      let acroFormIdString = pdfBuffer.slice(acroFormPosition - index, acroFormIdEnd).toString();
+
+      if (acroFormIdString[0] == '\n') {
+        break;
+      }
+
+      foundAcroFormId = acroFormIdString;
+      acroFormStart = acroFormPosition - index;
+    }
+
+    const pdfSlice = pdfBuffer.slice(acroFormStart);
     const acroForm = pdfSlice.slice(0, pdfSlice.indexOf('endobj')).toString();
-    const acroFormFirsRow = acroForm.split('\n')[0];
-    acroFormId = parseInt(acroFormFirsRow.split(' ')[0]);
+    acroFormId = parseInt(foundAcroFormId);
     const acroFormFields = acroForm.slice(acroForm.indexOf('/Fields [') + 9, acroForm.indexOf(']'));
     fieldIds = acroFormFields.split(' ').filter((element, index) => index % 3 === 0).map(fieldId => new _pdfkitReferenceMock.default(fieldId));
   }

--- a/dist/helpers/plainAddPlaceholder/index.js
+++ b/dist/helpers/plainAddPlaceholder/index.js
@@ -48,6 +48,9 @@ const isContainBufferRootWithAcroform = pdf => {
 const plainAddPlaceholder = ({
   pdfBuffer,
   reason,
+  contactInfo = 'emailfromp1289@gmail.com',
+  name = 'Name from p12',
+  location = 'Location from p12',
   signatureLength = _const.DEFAULT_SIGNATURE_LENGTH
 }) => {
   let pdf = (0, _removeTrailingNewLine.default)(pdfBuffer);
@@ -82,6 +85,9 @@ const plainAddPlaceholder = ({
     pdf: pdfKitMock,
     pdfBuffer,
     reason,
+    contactInfo,
+    name,
+    location,
     signatureLength
   });
 

--- a/dist/helpers/plainAddPlaceholder/readPdf.js
+++ b/dist/helpers/plainAddPlaceholder/readPdf.js
@@ -5,8 +5,6 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.default = void 0;
 
-var _SignPdfError = _interopRequireDefault(require("../../SignPdfError"));
-
 var _readRefTable = _interopRequireDefault(require("./readRefTable"));
 
 var _findObject = _interopRequireDefault(require("./findObject"));
@@ -30,7 +28,13 @@ const readPdf = pdfBuffer => {
   xRefPosition = parseInt(xRefPosition);
   const refTable = (0, _readRefTable.default)(pdfBuffer);
   let rootSlice = trailer.slice(trailer.indexOf('/Root'));
-  rootSlice = rootSlice.slice(0, rootSlice.indexOf('/', 1));
+  let rootIndex = rootSlice.indexOf('/', 1);
+
+  if (rootIndex === -1) {
+    rootIndex = rootSlice.indexOf('>', 1);
+  }
+
+  rootSlice = rootSlice.slice(0, rootIndex);
   const rootRef = rootSlice.slice(6).toString().trim(); // /Root + at least one space
 
   const root = (0, _findObject.default)(pdfBuffer, refTable, rootRef).toString();

--- a/src/helpers/pdfkitAddPlaceholder.js
+++ b/src/helpers/pdfkitAddPlaceholder.js
@@ -46,10 +46,28 @@ const pdfkitAddPlaceholder = ({
     let acroFormId;
 
     if (isAcroFormExists) {
-        const pdfSlice = pdfBuffer.slice(acroFormPosition - 12);
+        let acroFormStart = acroFormPosition;
+        // 10 is the distance between "/Type /AcroForm" and AcroFrom ID
+        const charsUntilIdEnd = 10
+        const acroFormIdEnd = acroFormPosition - charsUntilIdEnd;
+        // Let's find AcroForm ID by trying to find the "\n" before the ID
+        // 12 is a enough space to find the "\n" (generally it's 2 or 3, but I'm giving a big space though)
+        const maxAcroFormIdLength = 12
+        let foundAcroFormId = ''
+        for (let index = charsUntilIdEnd + 1; index < charsUntilIdEnd + maxAcroFormIdLength; index++) {
+            let acroFormIdString = pdfBuffer.slice(acroFormPosition - index, acroFormIdEnd).toString()
+  
+            if (acroFormIdString[0] == '\n') {
+                break
+            }
+  
+            foundAcroFormId = acroFormIdString
+            acroFormStart = acroFormPosition - index;
+        }
+  
+        const pdfSlice = pdfBuffer.slice(acroFormStart);
         const acroForm = pdfSlice.slice(0, pdfSlice.indexOf('endobj')).toString();
-        const acroFormFirsRow = acroForm.split('\n')[0];
-        acroFormId = parseInt(acroFormFirsRow.split(' ')[0]);
+        acroFormId = parseInt(foundAcroFormId);
 
         const acroFormFields = acroForm.slice(acroForm.indexOf('/Fields [') + 9, acroForm.indexOf(']'));
         fieldIds = acroFormFields

--- a/src/signpdf.test.js
+++ b/src/signpdf.test.js
@@ -15,23 +15,32 @@ const createPdf = params => new Promise((resolve) => {
         placeholder: {},
         text: 'node-signpdf',
         addSignaturePlaceholder: true,
+        pages: 1,
         ...params,
     };
 
     const pdf = new PDFDocument({
-        autoFirstPage: true,
+        autoFirstPage: false,
         size: 'A4',
         layout: 'portrait',
         bufferPages: true,
     });
     pdf.info.CreationDate = '';
 
-    // Add some content to the page
-    pdf
-        .fillColor('#333')
-        .fontSize(25)
-        .moveDown()
-        .text(requestParams.text);
+    if (requestParams.pages < 1) {
+        requestParams.pages = 1
+    }
+
+    // Add some content to the page(s)
+    for (let i = 0; i < requestParams.pages; i++) {
+        pdf
+            .addPage()
+            .fillColor('#333')
+            .fontSize(25)
+            .moveDown()
+            .text(requestParams.text)
+            .save();
+    }
 
     // Collect the ouput PDF
     // and, when done, resolve with it stored in a Buffer
@@ -99,6 +108,7 @@ describe('Test signing', () => {
                     signatureLength: 2,
                 },
             });
+
             const p12Buffer = fs.readFileSync(`${__dirname}/../resources/certificate.p12`);
 
             signer.sign(pdfBuffer, p12Buffer);
@@ -176,6 +186,33 @@ describe('Test signing', () => {
         expect(typeof signature === 'string').toBe(true);
         expect(signedData instanceof Buffer).toBe(true);
     });
+    it('signs big PDF twice producing big AcroForm ID on the first time', async () => {
+      let pdfBuffer = await createPdf({
+          pages: 100,
+      });
+      const p12Buffer = fs.readFileSync(`${__dirname}/../resources/certificate.p12`);
+
+      pdfBuffer = signer.sign(pdfBuffer, p12Buffer);
+      expect(pdfBuffer instanceof Buffer).toBe(true);
+
+      const {signature, signedData} = extractSignature(pdfBuffer);
+      expect(typeof signature === 'string').toBe(true);
+      expect(signedData instanceof Buffer).toBe(true);
+      
+      const secondP12Buffer = fs.readFileSync(`${__dirname}/../resources/withpass.p12`);
+      pdfBuffer = plainAddPlaceholder({
+          pdfBuffer: pdfBuffer,
+          reason: 'second',
+          location: 'test location',
+          signatureLength: 1592,
+      });
+      pdfBuffer = signer.sign(pdfBuffer, secondP12Buffer, {passphrase: 'node-signpdf'});
+      expect(pdfBuffer instanceof Buffer).toBe(true);
+      
+      const {signature: secondSignature, signedData: secondSignatureData} = extractSignature(pdfBuffer, 2);
+      expect(typeof secondSignature === 'string').toBe(true);
+      expect(secondSignatureData instanceof Buffer).toBe(true);
+    })
     it('signs a ready pdf containing a link', async () => {
         const p12Buffer = fs.readFileSync(`${__dirname}/../resources/certificate.p12`);
         let pdfBuffer = fs.readFileSync(`${__dirname}/../resources/including-a-link.pdf`);


### PR DESCRIPTION
Currently `pdfkitAddPlaceholder` tries to get the AcroForm ID by extracting it from AcroForm object, but it fails when the ID has 3 digits (or eventually more), it is currently prepared for a 2 digit ID.

I modified the code to count the digits before getting the AcroForm object.