### PR TITLE
Adding findByteRange helper

### DIFF
--- a/dist/helpers/findByteRange.js
+++ b/dist/helpers/findByteRange.js
@@ -1,0 +1,38 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = void 0;
+
+var _SignPdfError = _interopRequireDefault(require("../SignPdfError"));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+/**
+ * Finds the ByteRange within a given PDF Buffer if one exists
+ *
+ * @param {Buffer} pdf
+ * @returns {Object} {byteRangeString: String, byteRange: String[]}
+ */
+const findByteRange = pdf => {
+  if (!(pdf instanceof Buffer)) {
+    throw new _SignPdfError.default('PDF expected as Buffer.', _SignPdfError.default.TYPE_INPUT);
+  }
+
+  const byteRangeMatch = /\/ByteRange\s*\[{1}\s*(?:(?:\d*|\/\*{10})\s+){3}(?:\d+|\/\*{10}){1}\s*\]{1}/g.exec(pdf);
+
+  if (!byteRangeMatch) {
+    throw new _SignPdfError.default('No ByteRangeString found within PDF buffer', _SignPdfError.default.TYPE_PARSE);
+  }
+
+  const byteRangeString = byteRangeMatch[0];
+  const byteRange = byteRangeString.match(/[^\[\s]*(?:\d|\/\*{10})/g);
+  return {
+    byteRangeString,
+    byteRange
+  };
+};
+
+var _default = findByteRange;
+exports.default = _default;

--- a/dist/helpers/index.js
+++ b/dist/helpers/index.js
@@ -27,6 +27,12 @@ Object.defineProperty(exports, "removeTrailingNewLine", {
     return _removeTrailingNewLine.default;
   }
 });
+Object.defineProperty(exports, "findByteRange", {
+  enumerable: true,
+  get: function () {
+    return _findByteRange.default;
+  }
+});
 
 var _extractSignature = _interopRequireDefault(require("./extractSignature"));
 
@@ -35,6 +41,8 @@ var _pdfkitAddPlaceholder = _interopRequireDefault(require("./pdfkitAddPlacehold
 var _plainAddPlaceholder = _interopRequireDefault(require("./plainAddPlaceholder"));
 
 var _removeTrailingNewLine = _interopRequireDefault(require("./removeTrailingNewLine"));
+
+var _findByteRange = _interopRequireDefault(require("./findByteRange"));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 

--- a/dist/signpdf.js
+++ b/dist/signpdf.js
@@ -45,14 +45,10 @@ class SignPdf {
 
     let pdf = (0, _helpers.removeTrailingNewLine)(pdfBuffer); // Find the ByteRange placeholder.
 
-    const byteRangePlaceholder = [0, `/${this.byteRangePlaceholder}`, `/${this.byteRangePlaceholder}`, `/${this.byteRangePlaceholder}`];
-    const byteRangeString = `/ByteRange [${byteRangePlaceholder.join(' ')}]`;
-    const byteRangePos = pdf.indexOf(byteRangeString);
-
-    if (byteRangePos === -1) {
-      throw new _SignPdfError.default(`Could not find ByteRange placeholder: ${byteRangeString}`, _SignPdfError.default.TYPE_PARSE);
-    } // Calculate the actual ByteRange that needs to replace the placeholder.
-
+    const {
+      byteRangeString
+    } = (0, _helpers.findByteRange)(pdf);
+    const byteRangePos = pdf.indexOf(byteRangeString); // Calculate the actual ByteRange that needs to replace the placeholder.
 
     const byteRangeEnd = byteRangePos + byteRangeString.length;
     const contentsTagPos = pdf.indexOf('/Contents ', byteRangeEnd);

--- a/src/__snapshots__/signpdf.test.js.snap
+++ b/src/__snapshots__/signpdf.test.js.snap
@@ -8,6 +8,6 @@ exports[`Test signing expects P12 certificate to be Buffer 1`] = `"p12 certifica
 
 exports[`Test signing expects PDF to be Buffer 1`] = `"PDF expected as Buffer."`;
 
-exports[`Test signing expects PDF to contain a ByteRange placeholder 1`] = `"Could not find ByteRange placeholder: /ByteRange [0 /********** /********** /**********]"`;
+exports[`Test signing expects PDF to contain a ByteRange placeholder 1`] = `"No ByteRangeString found within PDF buffer"`;
 
 exports[`Test signing expects a reasonably sized placeholder 1`] = `"Signature exceeds placeholder length: 3224 > 4"`;

--- a/src/helpers/__snapshots__/index.test.js.snap
+++ b/src/helpers/__snapshots__/index.test.js.snap
@@ -6,5 +6,6 @@ Array [
   "pdfkitAddPlaceholder",
   "plainAddPlaceholder",
   "removeTrailingNewLine",
+  "findByteRange",
 ]
 `;

--- a/src/helpers/findByteRange.js
+++ b/src/helpers/findByteRange.js
@@ -1,0 +1,35 @@
+import SignPdfError from '../SignPdfError';
+
+/**
+ * Finds the ByteRange within a given PDF Buffer if one exists
+ *
+ * @param {Buffer} pdf
+ * @returns {Object} {byteRangeString: String, byteRange: String[]}
+ */
+const findByteRange = (pdf) => {
+    if (!(pdf instanceof Buffer)) {
+        throw new SignPdfError(
+            'PDF expected as Buffer.',
+            SignPdfError.TYPE_INPUT,
+        );
+    }
+
+    const byteRangeMatch = /\/ByteRange\s*\[{1}\s*(?:(?:\d*|\/\*{10})\s+){3}(?:\d+|\/\*{10}){1}\s*\]{1}/g.exec(pdf);
+
+    if (!byteRangeMatch) {
+        throw new SignPdfError(
+            'No ByteRangeString found within PDF buffer',
+            SignPdfError.TYPE_PARSE,
+        );
+    }
+
+    const byteRangeString = byteRangeMatch[0];
+    const byteRange = byteRangeString.match(/[^\[\s]*(?:\d|\/\*{10})/g);
+
+    return {
+      byteRangeString,
+      byteRange
+    };
+};
+
+export default findByteRange;

--- a/src/helpers/findByteRange.test.js
+++ b/src/helpers/findByteRange.test.js
@@ -1,0 +1,101 @@
+import PDFDocument from 'pdfkit';
+import findByteRange from './findByteRange';
+import SignPdfError from '../SignPdfError';
+import pdfkitAddPlaceholder from './pdfkitAddPlaceholder';
+
+/**
+ * Creates a Buffer containing a PDF.
+ * Returns a Promise that is resolved with the resulting Buffer of the PDFDocument.
+ * @returns {Promise<Buffer>}
+ */
+const createPdf = (params = {
+    placeholder: {},
+    text: 'node-signpdf',
+}) => new Promise((resolve) => {
+    const pdf = new PDFDocument({
+        autoFirstPage: true,
+        size: 'A4',
+        layout: 'portrait',
+        bufferPages: true,
+    });
+    pdf.info.CreationDate = '';
+
+    // Add some content to the page
+    pdf
+        .fillColor('#333')
+        .fontSize(25)
+        .moveDown()
+        .text(params.text);
+
+    // Collect the ouput PDF
+    // and, when done, resolve with it stored in a Buffer
+    const pdfChunks = [];
+    pdf.on('data', (data) => {
+        pdfChunks.push(data);
+    });
+    pdf.on('end', () => {
+        resolve(Buffer.concat(pdfChunks));
+    });
+
+    // Externally (to PDFKit) add the signature placeholder.
+    const refs = pdfkitAddPlaceholder({
+        pdf,
+        pdfBuffer: Buffer.from([pdf]),
+        reason: 'I am the author',
+        ...params.placeholder,
+    });
+    // Externally end the streams of the created objects.
+    // PDFKit doesn't know much about them, so it won't .end() them.
+    Object.keys(refs).forEach(key => refs[key].end());
+
+    // Also end the PDFDocument stream.
+    // See pdf.on('end'... on how it is then converted to Buffer.
+    pdf.end();
+});
+
+describe('findByteRange', () => {
+    it('expects PDF to be Buffer', () => {
+        try {
+            findByteRange('non-buffer');
+            expect('here').not.toBe('here');
+        } catch (e) {
+            expect(e instanceof SignPdfError).toBe(true);
+            expect(e.type).toBe(SignPdfError.TYPE_INPUT);
+        }
+    });
+    it('expects PDF to have a placeholder', () => {
+        try {
+            const pdf = new PDFDocument({
+                autoFirstPage: true,
+                size: 'A4',
+                layout: 'portrait',
+                bufferPages: true,
+            });
+            pdf.info.CreationDate = '';
+
+            findByteRange(Buffer.from([pdf]));
+            expect('here').not.toBe('here');
+        } catch (e) {
+            expect(e instanceof SignPdfError).toBe(true);
+            expect(e.type).toBe(SignPdfError.TYPE_PARSE);
+        }
+    });
+    it('expects to return correct byteRangeString and byteRange', async () => {
+        try {
+            const pdfBuffer = await createPdf({
+                placeholder: {
+                    signatureLength: 1612,
+                },
+            });
+
+            const {byteRangeString, byteRange} = findByteRange(pdfBuffer);
+            expect(byteRangeString).toBe('/ByteRange [0 /********** /********** /**********]');
+            expect(byteRange[0]).toBe('0');
+            expect(byteRange[1]).toBe('/**********');
+            expect(byteRange[2]).toBe('/**********');
+            expect(byteRange[3]).toBe('/**********');
+        } catch (e) {
+            expect('here').not.toBe('here');
+        }
+    });
+});

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -2,5 +2,6 @@ export {default as extractSignature} from './extractSignature';
 export {default as pdfkitAddPlaceholder} from './pdfkitAddPlaceholder';
 export {default as plainAddPlaceholder} from './plainAddPlaceholder';
 export {default as removeTrailingNewLine} from './removeTrailingNewLine';
+export {default as findByteRange} from './findByteRange';
 
 'This string is added so that jest collects coverage for this file'; // eslint-disable-line

--- a/src/signpdf.js
+++ b/src/signpdf.js
@@ -1,6 +1,6 @@
 import forge from 'node-forge';
 import SignPdfError from './SignPdfError';
-import {removeTrailingNewLine} from './helpers';
+import {removeTrailingNewLine, findByteRange} from './helpers';
 
 export {default as SignPdfError} from './SignPdfError';
 
@@ -39,20 +39,8 @@ export class SignPdf {
         let pdf = removeTrailingNewLine(pdfBuffer);
 
         // Find the ByteRange placeholder.
-        const byteRangePlaceholder = [
-            0,
-            `/${this.byteRangePlaceholder}`,
-            `/${this.byteRangePlaceholder}`,
-            `/${this.byteRangePlaceholder}`,
-        ];
-        const byteRangeString = `/ByteRange [${byteRangePlaceholder.join(' ')}]`;
+        const { byteRangeString } = findByteRange(pdf);
         const byteRangePos = pdf.indexOf(byteRangeString);
-        if (byteRangePos === -1) {
-            throw new SignPdfError(
-                `Could not find ByteRange placeholder: ${byteRangeString}`,
-                SignPdfError.TYPE_PARSE,
-            );
-        }
 
         // Calculate the actual ByteRange that needs to replace the placeholder.
         const byteRangeEnd = byteRangePos + byteRangeString.length;


### PR DESCRIPTION
Per #98, this PR adds a findByteRange that properly parses the ByteRange field regardless of the spacing included inside. The function returns a `byteRangeString` and a `byteRange` array of values.