### PR TITLE
NEW Decouple signing logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,11 @@ Once you have the placeholder, just [[sign the document]](#sign-the-document).
 
 ```javascript
 import signer from 'node-signpdf';
+import P12Signer from 'node-signpdf/dist/signers';
 ...
-const signedPdf = signer.sign(
+const signedPdf = await signer.sign(
   fs.readFileSync(PATH_TO_PDF_FILE),
-  fs.readFileSync(PATH_TO_P12_CERTIFICATE),
+  new P12Signer(fs.readFileSync(PATH_TO_P12_CERTIFICATE)),
 );
 ```
 
@@ -82,6 +83,23 @@ This package provides two [helpers](https://github.com/vbuch/node-signpdf/blob/m
 ### Generate and apply signature
 
 That's where the Signer kicks in. Given a PDF and a P12 certificate a signature is generated in detached mode and is replaced in the placeholder. This is best demonstrated in [the tests](https://github.com/vbuch/node-signpdf/blob/master/src/signpdf.test.js#L100).
+
+### Generate a signature using your own Signer
+
+The `PDFSigner.sign()` method accepts a `Signer` as the second argument, if you need to implement your own signing logic, you can create your own `Signer` subclass and implement the `sign` method (which accepts the pdfBuffer) and sign this yourself.
+
+```javascript
+import signer from 'node-signpdf';
+import Signer from 'node-signpdf/dist/signer';
+...
+class MySigner extends Signer {
+    sign(pdfBuffer) {
+        ...
+        return Buffer.from(...);
+    }
+}
+signer.sign(pdfBuffer, new MySigner());
+```
 
 ## Dependencies
 

--- a/dist/signer.js
+++ b/dist/signer.js
@@ -1,0 +1,19 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = void 0;
+
+var _SignPdfError = _interopRequireDefault(require("./SignPdfError"));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+class Signer {
+  sign() {
+    throw new _SignPdfError.default(`sign not implemented on ${this.constructor.name}`, _SignPdfError.default.TYPE_INPUT);
+  }
+
+}
+
+exports.default = Signer;

--- a/dist/signers/index.js
+++ b/dist/signers/index.js
@@ -1,0 +1,17 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+Object.defineProperty(exports, "P12Signer", {
+  enumerable: true,
+  get: function () {
+    return _p12Signer.default;
+  }
+});
+
+var _p12Signer = _interopRequireDefault(require("./p12Signer"));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+'This string is added so that jest collects coverage for this file'; // eslint-disable-line

--- a/dist/signers/p12Signer.js
+++ b/dist/signers/p12Signer.js
@@ -1,0 +1,105 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = void 0;
+
+var _nodeForge = _interopRequireDefault(require("node-forge"));
+
+var _SignPdfError = _interopRequireDefault(require("../SignPdfError"));
+
+var _signer = _interopRequireDefault(require("../signer"));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+class P12Signer extends _signer.default {
+  constructor(p12Buffer, additionalOptions = {}) {
+    super();
+
+    if (!(p12Buffer instanceof Buffer)) {
+      throw new _SignPdfError.default('p12 certificate expected as Buffer.', _SignPdfError.default.TYPE_INPUT);
+    }
+
+    this.options = {
+      asn1StrictParsing: false,
+      passphrase: '',
+      ...additionalOptions
+    };
+    this.cert = _nodeForge.default.util.createBuffer(p12Buffer.toString('binary'));
+  }
+
+  sign(pdfBuffer) {
+    if (!(pdfBuffer instanceof Buffer)) {
+      throw new _SignPdfError.default('PDF expected as Buffer.', _SignPdfError.default.TYPE_INPUT);
+    } // Convert Buffer P12 to a forge implementation.
+
+
+    const p12Asn1 = _nodeForge.default.asn1.fromDer(this.cert);
+
+    const p12 = _nodeForge.default.pkcs12.pkcs12FromAsn1(p12Asn1, this.options.asn1StrictParsing, this.options.passphrase); // Extract safe bags by type.
+    // We will need all the certificates and the private key.
+
+
+    const certBags = p12.getBags({
+      bagType: _nodeForge.default.pki.oids.certBag
+    })[_nodeForge.default.pki.oids.certBag];
+
+    const keyBags = p12.getBags({
+      bagType: _nodeForge.default.pki.oids.pkcs8ShroudedKeyBag
+    })[_nodeForge.default.pki.oids.pkcs8ShroudedKeyBag];
+
+    const privateKey = keyBags[0].key; // Here comes the actual PKCS#7 signing.
+
+    const p7 = _nodeForge.default.pkcs7.createSignedData(); // Start off by setting the content.
+
+
+    p7.content = _nodeForge.default.util.createBuffer(pdfBuffer.toString('binary')); // Then add all the certificates (-cacerts & -clcerts)
+    // Keep track of the last found client certificate.
+    // This will be the public key that will be bundled in the signature.
+
+    let certificate;
+    Object.keys(certBags).forEach(i => {
+      const {
+        publicKey
+      } = certBags[i].cert;
+      p7.addCertificate(certBags[i].cert); // Try to find the certificate that matches the private key.
+
+      if (privateKey.n.compareTo(publicKey.n) === 0 && privateKey.e.compareTo(publicKey.e) === 0) {
+        certificate = certBags[i].cert;
+      }
+    });
+
+    if (typeof certificate === 'undefined') {
+      throw new _SignPdfError.default('Failed to find a certificate that matches the private key.', _SignPdfError.default.TYPE_INPUT);
+    } // Add a sha256 signer. That's what Adobe.PPKLite adbe.pkcs7.detached expects.
+
+
+    p7.addSigner({
+      key: privateKey,
+      certificate,
+      digestAlgorithm: _nodeForge.default.pki.oids.sha256,
+      authenticatedAttributes: [{
+        type: _nodeForge.default.pki.oids.contentType,
+        value: _nodeForge.default.pki.oids.data
+      }, {
+        type: _nodeForge.default.pki.oids.messageDigest // value will be auto-populated at signing time
+
+      }, {
+        type: _nodeForge.default.pki.oids.signingTime,
+        // value can also be auto-populated at signing time
+        // We may also support passing this as an option to sign().
+        // Would be useful to match the creation time of the document for example.
+        value: new Date()
+      }]
+    }); // Sign in detached mode.
+
+    p7.sign({
+      detached: true
+    });
+    return Buffer.from(_nodeForge.default.asn1.toDer(p7.toAsn1()).getBytes(), 'binary');
+  }
+
+}
+
+exports.default = P12Signer;

--- a/dist/signpdf.js
+++ b/dist/signpdf.js
@@ -16,8 +16,6 @@ Object.defineProperty(exports, "SignPdfError", {
 });
 exports.default = exports.SignPdf = exports.DEFAULT_BYTE_RANGE_PLACEHOLDER = void 0;
 
-var _nodeForge = _interopRequireDefault(require("node-forge"));
-
 var _SignPdfError = _interopRequireDefault(require("./SignPdfError"));
 
 var _helpers = require("./helpers");
@@ -25,6 +23,7 @@ var _helpers = require("./helpers");
 Object.keys(_helpers).forEach(function (key) {
   if (key === "default" || key === "__esModule") return;
   if (Object.prototype.hasOwnProperty.call(_exportNames, key)) return;
+  if (key in exports && exports[key] === _helpers[key]) return;
   Object.defineProperty(exports, key, {
     enumerable: true,
     get: function () {
@@ -32,6 +31,8 @@ Object.keys(_helpers).forEach(function (key) {
     }
   });
 });
+
+var _signer = _interopRequireDefault(require("./signer"));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -43,20 +44,22 @@ class SignPdf {
     this.byteRangePlaceholder = DEFAULT_BYTE_RANGE_PLACEHOLDER;
     this.lastSignature = null;
   }
+  /**
+   * Sign a PDF buffer with given signer
+   *
+   * @param {Buffer} pdfBuffer
+   * @param {Signer} signer
+   * @returns {Promise<Buffer>}
+   */
 
-  sign(pdfBuffer, p12Buffer, additionalOptions = {}) {
-    const options = {
-      asn1StrictParsing: false,
-      passphrase: '',
-      ...additionalOptions
-    };
 
+  async sign(pdfBuffer, signer) {
     if (!(pdfBuffer instanceof Buffer)) {
       throw new _SignPdfError.default('PDF expected as Buffer.', _SignPdfError.default.TYPE_INPUT);
     }
 
-    if (!(p12Buffer instanceof Buffer)) {
-      throw new _SignPdfError.default('p12 certificate expected as Buffer.', _SignPdfError.default.TYPE_INPUT);
+    if (!(signer instanceof _signer.default)) {
+      throw new _SignPdfError.default('signer must be a Signer class', _SignPdfError.default.TYPE_INPUT);
     }
 
     let pdf = (0, _helpers.removeTrailingNewLine)(pdfBuffer); // Find the ByteRange placeholder.
@@ -86,76 +89,11 @@ class SignPdf {
 
     pdf = Buffer.concat([pdf.slice(0, byteRangePos), Buffer.from(actualByteRange), pdf.slice(byteRangeEnd)]); // Remove the placeholder signature
 
-    pdf = Buffer.concat([pdf.slice(0, byteRange[1]), pdf.slice(byteRange[2], byteRange[2] + byteRange[3])]); // Convert Buffer P12 to a forge implementation.
+    pdf = Buffer.concat([pdf.slice(0, byteRange[1]), pdf.slice(byteRange[2], byteRange[2] + byteRange[3])]); // signing
 
-    const forgeCert = _nodeForge.default.util.createBuffer(p12Buffer.toString('binary'));
-
-    const p12Asn1 = _nodeForge.default.asn1.fromDer(forgeCert);
-
-    const p12 = _nodeForge.default.pkcs12.pkcs12FromAsn1(p12Asn1, options.asn1StrictParsing, options.passphrase); // Extract safe bags by type.
-    // We will need all the certificates and the private key.
-
-
-    const certBags = p12.getBags({
-      bagType: _nodeForge.default.pki.oids.certBag
-    })[_nodeForge.default.pki.oids.certBag];
-
-    const keyBags = p12.getBags({
-      bagType: _nodeForge.default.pki.oids.pkcs8ShroudedKeyBag
-    })[_nodeForge.default.pki.oids.pkcs8ShroudedKeyBag];
-
-    const privateKey = keyBags[0].key; // Here comes the actual PKCS#7 signing.
-
-    const p7 = _nodeForge.default.pkcs7.createSignedData(); // Start off by setting the content.
-
-
-    p7.content = _nodeForge.default.util.createBuffer(pdf.toString('binary')); // Then add all the certificates (-cacerts & -clcerts)
-    // Keep track of the last found client certificate.
-    // This will be the public key that will be bundled in the signature.
-
-    let certificate;
-    Object.keys(certBags).forEach(i => {
-      const {
-        publicKey
-      } = certBags[i].cert;
-      p7.addCertificate(certBags[i].cert); // Try to find the certificate that matches the private key.
-
-      if (privateKey.n.compareTo(publicKey.n) === 0 && privateKey.e.compareTo(publicKey.e) === 0) {
-        certificate = certBags[i].cert;
-      }
-    });
-
-    if (typeof certificate === 'undefined') {
-      throw new _SignPdfError.default('Failed to find a certificate that matches the private key.', _SignPdfError.default.TYPE_INPUT);
-    } // Add a sha256 signer. That's what Adobe.PPKLite adbe.pkcs7.detached expects.
-
-
-    p7.addSigner({
-      key: privateKey,
-      certificate,
-      digestAlgorithm: _nodeForge.default.pki.oids.sha256,
-      authenticatedAttributes: [{
-        type: _nodeForge.default.pki.oids.contentType,
-        value: _nodeForge.default.pki.oids.data
-      }, {
-        type: _nodeForge.default.pki.oids.messageDigest // value will be auto-populated at signing time
-
-      }, {
-        type: _nodeForge.default.pki.oids.signingTime,
-        // value can also be auto-populated at signing time
-        // We may also support passing this as an option to sign().
-        // Would be useful to match the creation time of the document for example.
-        value: new Date()
-      }]
-    }); // Sign in detached mode.
-
-    p7.sign({
-      detached: true
-    }); // Check if the PDF has a good enough placeholder to fit the signature.
-
-    const raw = _nodeForge.default.asn1.toDer(p7.toAsn1()).getBytes(); // placeholderLength represents the length of the HEXified symbols but we're
+    const raw = await signer.sign(pdf); // Check if the PDF has a good enough placeholder to fit the signature.
+    // placeholderLength represents the length of the HEXified symbols but we're
     // checking the actual lengths.
-
 
     if (raw.length * 2 > placeholderLength) {
       throw new _SignPdfError.default(`Signature exceeds placeholder length: ${raw.length * 2} > ${placeholderLength}`, _SignPdfError.default.TYPE_INPUT);

--- a/package.json
+++ b/package.json
@@ -62,6 +62,6 @@
         "eslint-plugin-jest": "^22.4.1",
         "jest": "^24.5.0",
         "node-forge": "^0.10.0",
-        "pdfkit": "^0.10.0"
+        "pdfkit": "~0.10.0"
     }
 }

--- a/src/__snapshots__/signer.test.js.snap
+++ b/src/__snapshots__/signer.test.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Test signing sign method must be implemented 1`] = `"sign not implemented on Signer"`;

--- a/src/__snapshots__/signpdf.test.js.snap
+++ b/src/__snapshots__/signpdf.test.js.snap
@@ -4,10 +4,10 @@ exports[`Test signing errors on wrong certificate passphrase 1`] = `"PKCS#12 MAC
 
 exports[`Test signing errors when no matching certificate is found in bags 1`] = `"Failed to find a certificate that matches the private key."`;
 
-exports[`Test signing expects P12 certificate to be Buffer 1`] = `"p12 certificate expected as Buffer."`;
-
 exports[`Test signing expects PDF to be Buffer 1`] = `"PDF expected as Buffer."`;
 
 exports[`Test signing expects PDF to contain a ByteRange placeholder 1`] = `"No ByteRangeStrings found within PDF buffer"`;
 
 exports[`Test signing expects a reasonably sized placeholder 1`] = `"Signature exceeds placeholder length: 3224 > 4"`;
+
+exports[`Test signing expects signer Signer 1`] = `"signer must be a Signer class"`;

--- a/src/helpers.test.js
+++ b/src/helpers.test.js
@@ -3,6 +3,7 @@ import PDFDocument from 'pdfkit';
 import signer from './signpdf';
 import {pdfkitAddPlaceholder, extractSignature} from './helpers';
 import SignPdfError from './SignPdfError';
+import P12Signer from './signers/p12Signer';
 
 /**
  * Creates a Buffer containing a PDF.
@@ -63,7 +64,7 @@ describe('Helpers', () => {
         });
         const p12Buffer = fs.readFileSync(`${__dirname}/../resources/certificate.p12`);
 
-        const signedPdfBuffer = signer.sign(pdfBuffer, p12Buffer);
+        const signedPdfBuffer = await signer.sign(pdfBuffer, new P12Signer(p12Buffer));
         const originalSignature = signer.lastSignature;
 
         const {signature} = extractSignature(signedPdfBuffer);

--- a/src/signer.js
+++ b/src/signer.js
@@ -1,0 +1,10 @@
+import SignPdfError from './SignPdfError';
+
+export default class Signer {
+    sign() {
+        throw new SignPdfError(
+            `sign not implemented on ${this.constructor.name}`,
+            SignPdfError.TYPE_INPUT,
+        );
+    }
+}

--- a/src/signer.test.js
+++ b/src/signer.test.js
@@ -1,0 +1,16 @@
+import SignPdfError from './SignPdfError';
+import Signer from './signer';
+
+describe('Test signing', () => {
+    it('sign method must be implemented', async () => {
+        try {
+            const signer = new Signer(Buffer.from(''));
+            await signer.sign('non-buffer');
+            expect('here').not.toBe('here');
+        } catch (e) {
+            expect(e instanceof SignPdfError).toBe(true);
+            expect(e.type).toBe(SignPdfError.TYPE_INPUT);
+            expect(e.message).toMatchSnapshot();
+        }
+    });
+});

--- a/src/signers/__snapshots__/index.test.js.snap
+++ b/src/signers/__snapshots__/index.test.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Signers index Exports expected signers 1`] = `
+Array [
+  "P12Signer",
+]
+`;

--- a/src/signers/__snapshots__/p12Signer.test.js.snap
+++ b/src/signers/__snapshots__/p12Signer.test.js.snap
@@ -1,0 +1,5 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Test signing expects P12 certificate to be Buffer 1`] = `"p12 certificate expected as Buffer."`;
+
+exports[`Test signing expects pdf to be Buffer 1`] = `"PDF expected as Buffer."`;

--- a/src/signers/index.js
+++ b/src/signers/index.js
@@ -1,0 +1,3 @@
+export {default as P12Signer} from './p12Signer';
+
+'This string is added so that jest collects coverage for this file'; // eslint-disable-line

--- a/src/signers/index.test.js
+++ b/src/signers/index.test.js
@@ -1,0 +1,7 @@
+import * as helpers from './index';
+
+describe('Signers index', () => {
+    it('Exports expected signers', () => {
+        expect(Object.keys(helpers)).toMatchSnapshot();
+    });
+});

--- a/src/signers/p12Signer.js
+++ b/src/signers/p12Signer.js
@@ -1,0 +1,103 @@
+import forge from 'node-forge';
+import SignPdfError from '../SignPdfError';
+import Signer from '../signer';
+
+export default class P12Signer extends Signer {
+    constructor(p12Buffer, additionalOptions = {}) {
+        super();
+        if (!(p12Buffer instanceof Buffer)) {
+            throw new SignPdfError(
+                'p12 certificate expected as Buffer.',
+                SignPdfError.TYPE_INPUT,
+            );
+        }
+        this.options = {
+            asn1StrictParsing: false,
+            passphrase: '',
+            ...additionalOptions,
+        };
+        this.cert = forge.util.createBuffer(p12Buffer.toString('binary'));
+    }
+
+    sign(pdfBuffer) {
+        if (!(pdfBuffer instanceof Buffer)) {
+            throw new SignPdfError(
+                'PDF expected as Buffer.',
+                SignPdfError.TYPE_INPUT,
+            );
+        }
+        // Convert Buffer P12 to a forge implementation.
+        const p12Asn1 = forge.asn1.fromDer(this.cert);
+        const p12 = forge.pkcs12.pkcs12FromAsn1(
+            p12Asn1,
+            this.options.asn1StrictParsing,
+            this.options.passphrase,
+        );
+
+        // Extract safe bags by type.
+        // We will need all the certificates and the private key.
+        const certBags = p12.getBags({
+            bagType: forge.pki.oids.certBag,
+        })[forge.pki.oids.certBag];
+        const keyBags = p12.getBags({
+            bagType: forge.pki.oids.pkcs8ShroudedKeyBag,
+        })[forge.pki.oids.pkcs8ShroudedKeyBag];
+
+        const privateKey = keyBags[0].key;
+        // Here comes the actual PKCS#7 signing.
+        const p7 = forge.pkcs7.createSignedData();
+        // Start off by setting the content.
+        p7.content = forge.util.createBuffer(pdfBuffer.toString('binary'));
+
+        // Then add all the certificates (-cacerts & -clcerts)
+        // Keep track of the last found client certificate.
+        // This will be the public key that will be bundled in the signature.
+        let certificate;
+        Object.keys(certBags).forEach((i) => {
+            const {publicKey} = certBags[i].cert;
+
+            p7.addCertificate(certBags[i].cert);
+
+            // Try to find the certificate that matches the private key.
+            if (privateKey.n.compareTo(publicKey.n) === 0
+                && privateKey.e.compareTo(publicKey.e) === 0
+            ) {
+                certificate = certBags[i].cert;
+            }
+        });
+
+        if (typeof certificate === 'undefined') {
+            throw new SignPdfError(
+                'Failed to find a certificate that matches the private key.',
+                SignPdfError.TYPE_INPUT,
+            );
+        }
+
+        // Add a sha256 signer. That's what Adobe.PPKLite adbe.pkcs7.detached expects.
+        p7.addSigner({
+            key: privateKey,
+            certificate,
+            digestAlgorithm: forge.pki.oids.sha256,
+            authenticatedAttributes: [
+                {
+                    type: forge.pki.oids.contentType,
+                    value: forge.pki.oids.data,
+                }, {
+                    type: forge.pki.oids.messageDigest,
+                    // value will be auto-populated at signing time
+                }, {
+                    type: forge.pki.oids.signingTime,
+                    // value can also be auto-populated at signing time
+                    // We may also support passing this as an option to sign().
+                    // Would be useful to match the creation time of the document for example.
+                    value: new Date(),
+                },
+            ],
+        });
+
+        // Sign in detached mode.
+        p7.sign({detached: true});
+
+        return Buffer.from(forge.asn1.toDer(p7.toAsn1()).getBytes(), 'binary');
+    }
+}

--- a/src/signers/p12Signer.test.js
+++ b/src/signers/p12Signer.test.js
@@ -1,0 +1,27 @@
+import SignPdfError from '../SignPdfError';
+import P12Signer from './p12Signer';
+
+describe('Test signing', () => {
+    it('expects P12 certificate to be Buffer', () => {
+        try {
+            // eslint-disable-next-line no-new
+            new P12Signer('non-buffer');
+            expect('here').not.toBe('here');
+        } catch (e) {
+            expect(e instanceof SignPdfError).toBe(true);
+            expect(e.type).toBe(SignPdfError.TYPE_INPUT);
+            expect(e.message).toMatchSnapshot();
+        }
+    });
+    it('expects pdf to be Buffer', async () => {
+        try {
+            const signer = new P12Signer(Buffer.from(''));
+            await signer.sign('non-buffer');
+            expect('here').not.toBe('here');
+        } catch (e) {
+            expect(e instanceof SignPdfError).toBe(true);
+            expect(e.type).toBe(SignPdfError.TYPE_INPUT);
+            expect(e.message).toMatchSnapshot();
+        }
+    });
+});


### PR DESCRIPTION
Currently I have a need to sign PDFs using an third party service (Azure KeyVault). This means the private key is not locally accessible and instead the signing is done asynchronously "off site". 

This means I can't provide a p12 certificate with a private key, so I need to provide my own signing logic which is also async.

As such this change introduces two major changes:

1. Signing is now an async task to allow signers to be async
2. Signers are now decoupled from the signing preparation process and a signed using a `Signer` subclass

Low level changes:

- Pin to 0.10 of PDFKit as v0.11 introduces acroform support that breaks signing
- Create an "abstract" `Signer` class that is responsible for performing the signing of the PDF
- Implement the `Signer` class to create a `P12Signer` (refactored from the `SignPdf.sign()` method)
- SignPdf.sign() is now async
- Docs update

---

I appreciate this change is quite opinionated and happy to take on feedback to make this acceptable:

eg:
1. Signers are class based, really they could just be a callable - I mainly did this to allow specific `instanceof` calls on the signer argument
2. Signing is now async (though this is a requirement for my usage, so can't change this and it be "useful" for me)