### PR TITLE
fix: Fix strange import usage to use helpers

### DIFF
--- a/src/signpdf.js
+++ b/src/signpdf.js
@@ -3,6 +3,7 @@ import SignPdfError from './SignPdfError';
 import {removeTrailingNewLine, findByteRange} from './helpers';
 
 export {default as SignPdfError} from './SignPdfError';
+export * from "./helpers";
 
 export const DEFAULT_BYTE_RANGE_PLACEHOLDER = '**********';
 


### PR DESCRIPTION
This PR was motivated by the ["Strange import usage #138"](https://github.com/vbuch/node-signpdf/issues/138) issue.

I hope to be able to use this library in a more succinct and direct way and as I imagined, the solution to this problem doesn't seem problematic for the library and offers its benefits.

So I hope you guys accept this solution.