### PR TITLE
Issue 183 signature is not pades compliant

### DIFF
--- a/src/signpdf.js
+++ b/src/signpdf.js
@@ -128,6 +128,8 @@ export class SignPdf {
         }
 
         // Add a sha256 signer. That's what Adobe.PPKLite adbe.pkcs7.detached expects.
+        // Note that the authenticatedAttributes order is relevant for correct EU signature validation:
+        // https://ec.europa.eu/digital-building-blocks/DSS/webapp-demo/validation
         p7.addSigner({
             key: privateKey,
             certificate,

--- a/src/signpdf.js
+++ b/src/signpdf.js
@@ -128,7 +128,8 @@ export class SignPdf {
         }
 
         // Add a sha256 signer. That's what Adobe.PPKLite adbe.pkcs7.detached expects.
-        // Note that the authenticatedAttributes order is relevant for correct EU signature validation:
+        // Note that the authenticatedAttributes order is relevant for correct
+        // EU signature validation:
         // https://ec.europa.eu/digital-building-blocks/DSS/webapp-demo/validation
         p7.addSigner({
             key: privateKey,

--- a/src/signpdf.js
+++ b/src/signpdf.js
@@ -137,14 +137,14 @@ export class SignPdf {
                     type: forge.pki.oids.contentType,
                     value: forge.pki.oids.data,
                 }, {
-                    type: forge.pki.oids.messageDigest,
-                    // value will be auto-populated at signing time
-                }, {
                     type: forge.pki.oids.signingTime,
                     // value can also be auto-populated at signing time
                     // We may also support passing this as an option to sign().
                     // Would be useful to match the creation time of the document for example.
                     value: new Date(),
+                }, {
+                    type: forge.pki.oids.messageDigest,
+                    // value will be auto-populated at signing time
                 },
             ],
         });


### PR DESCRIPTION
This solves: [Issue 183](https://github.com/vbuch/node-signpdf/issues/183)

The validation result "The signature is not intact!" was caused by the wrong order of authenticatedAttributes in [node-signpdf/src/signpdf.js](https://github.com/vbuch/node-signpdf/blob/7145a7e2265d5063ef2647f286c5644abbf21a7d/src/signpdf.js#L138).

This was found by  @victorgrodriguesm7 here: https://github.com/vbuch/node-signpdf/issues/70#issuecomment-861435746.

I changed the order and validated the result using https://ec.europa.eu/digital-building-blocks/DSS/webapp-demo/validation and the certificate in /ressources.

![image](https://user-images.githubusercontent.com/1309312/219896522-8300ba1c-487b-4bb9-8744-301a1da4d314.png)

![image](https://user-images.githubusercontent.com/1309312/219896796-189b4880-a4ae-4bf7-8e00-21d1f97304d0.png)