### PR TITLE
Ignore unnecessary files on the release

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,11 @@
         "digital signature"
     ],
     "main": "dist/signpdf.js",
+    "files": [
+        "dist",
+        "LICENSE",
+        "README.md"
+    ],
     "engines": {
         "node": ">=12"
     },


### PR DESCRIPTION
Before
```batch
 === Tarball Details ===
 name:          node-signpdf
 version:       1.5.0
 filename:      node-signpdf-1.5.0.tgz
 package size:  876.1 kB
 unpacked size: 1.1 MB
 shasum:        493997f08b7a6ec8d1ac34622860ba8e19fbc6de
 integrity:     sha512-mVvCGShYKX09X[...]nR15STDvUHefw==
 total files:   101
```
After
```batch
npm publish --dry-run

 📦  node-signpdf@1.5.0
 === Tarball Contents ===
 1.1kB LICENSE
 7.0kB README.md
 1.1kB dist/helpers/const.js
 2.4kB dist/helpers/extractSignature.js
 1.3kB dist/helpers/findByteRange.js
 1.5kB dist/helpers/index.js
 600B  dist/helpers/pdfkit/abstract_reference.js
 4.2kB dist/helpers/pdfkit/pdfobject.js
 4.4kB dist/helpers/pdfkitAddPlaceholder.js
 697B  dist/helpers/pdfkitReferenceMock.js
 1.7kB dist/helpers/plainAddPlaceholder/createBufferPageWithAnnotation.js
 691B  dist/helpers/plainAddPlaceholder/createBufferRootWithAcroform.js
 1.0kB dist/helpers/plainAddPlaceholder/createBufferTrailer.js
 856B  dist/helpers/plainAddPlaceholder/findObject.js
 723B  dist/helpers/plainAddPlaceholder/getIndexFromRef.js
 1.1kB dist/helpers/plainAddPlaceholder/getPageRef.js
 723B  dist/helpers/plainAddPlaceholder/getPagesDictionaryRef.js
 3.8kB dist/helpers/plainAddPlaceholder/index.js
 1.8kB dist/helpers/plainAddPlaceholder/readPdf.js
 3.8kB dist/helpers/plainAddPlaceholder/readRefTable.js
 1.5kB dist/helpers/plainAddPlaceholder/xrefToRefMap.js
 1.3kB dist/helpers/removeTrailingNewLine.js
 7.4kB dist/signpdf.js
 959B  dist/SignPdfError.js
 2.0kB package.json

 === Tarball Details ===
 name:          node-signpdf
 version:       1.5.0
 filename:      node-signpdf-1.5.0.tgz
 package size:  14.7 kB
 unpacked size: 53.5 kB
 shasum:        1d6d796b4a5c3e4662cdc50e7126fddcde3e6439
 integrity:     sha512-e+RsYOqJJggm/[...]CEy6CYk+XnKRQ==
 total files:   25
```