### PR TITLE
[utils] Signer.sign() types don't indicate it is async method

### DIFF
--- a/packages/signer-p12/dist/P12Signer.d.ts
+++ b/packages/signer-p12/dist/P12Signer.d.ts
@@ -14,6 +14,11 @@ export class P12Signer extends Signer {
         asn1StrictParsing: boolean;
     };
     cert: any;
+    /**
+     * @param {Buffer} pdfBuffer
+     * @returns {Buffer}
+     */
+    sign(pdfBuffer: Buffer): Buffer;
 }
 export type SignerOptions = {
     passphrase?: string;

--- a/packages/signer-p12/dist/P12Signer.d.ts.map
+++ b/packages/signer-p12/dist/P12Signer.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"P12Signer.d.ts","sourceRoot":"","sources":["../src/P12Signer.js"],"names":[],"mappings":"AAGA;;;;GAIG;AAEH;IACI;;;OAGG;IACH,uBAHW,MAAM,sBACN,aAAa,EAkBvB;IANG;oBAnBE,MAAM;2BACN,OAAO;MAsBR;IACD,UAAiE;CA4FxE;;iBApHS,MAAM;wBACN,OAAO;;uBALkB,gBAAgB"}
+{"version":3,"file":"P12Signer.d.ts","sourceRoot":"","sources":["../src/P12Signer.js"],"names":[],"mappings":"AAGA;;;;GAIG;AAEH;IACI;;;OAGG;IACH,uBAHW,MAAM,sBACN,aAAa,EAkBvB;IANG;oBAnBE,MAAM;2BACN,OAAO;MAsBR;IACD,UAAiE;IAGrE;;;OAGG;IACH,gBAHW,MAAM,GACJ,MAAM,CAsFlB;CACJ;;iBApHS,MAAM;wBACN,OAAO;;uBALkB,gBAAgB"}

--- a/packages/utils/dist/Signer.d.ts
+++ b/packages/utils/dist/Signer.d.ts
@@ -1,8 +1,8 @@
 export class Signer {
     /**
      * @param {Buffer} pdfBuffer
-     * @returns {Buffer}
+     * @returns {Promise<Buffer> | Buffer}
      */
-    sign(pdfBuffer: Buffer): Buffer;
+    sign(pdfBuffer: Buffer): Promise<Buffer> | Buffer;
 }
 //# sourceMappingURL=Signer.d.ts.map

--- a/packages/utils/dist/Signer.d.ts.map
+++ b/packages/utils/dist/Signer.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"Signer.d.ts","sourceRoot":"","sources":["../src/Signer.js"],"names":[],"mappings":"AAGA;IACI;;;OAGG;IACH,gBAHW,MAAM,GACJ,MAAM,CAOlB;CACJ"}
+{"version":3,"file":"Signer.d.ts","sourceRoot":"","sources":["../src/Signer.js"],"names":[],"mappings":"AAGA;IACI;;;OAGG;IACH,gBAHW,MAAM,GACJ,QAAQ,MAAM,CAAC,GAAG,MAAM,CAOpC;CACJ"}

--- a/packages/utils/dist/Signer.js
+++ b/packages/utils/dist/Signer.js
@@ -10,9 +10,9 @@ var _SignPdfError = require("./SignPdfError");
 class Signer {
   /**
    * @param {Buffer} pdfBuffer
-   * @returns {Buffer}
+   * @returns {Promise<Buffer> | Buffer}
    */
-  async sign(pdfBuffer) {
+  sign(pdfBuffer) {
     throw new _SignPdfError.SignPdfError(`sign() is not implemented on ${this.constructor.name}`, _SignPdfError.SignPdfError.TYPE_INPUT);
   }
 }

--- a/packages/utils/src/Signer.js
+++ b/packages/utils/src/Signer.js
@@ -4,9 +4,9 @@ import {SignPdfError} from './SignPdfError';
 export class Signer {
     /**
      * @param {Buffer} pdfBuffer
-     * @returns {Buffer}
+     * @returns {Promise<Buffer> | Buffer}
      */
-    async sign(pdfBuffer) {
+    sign(pdfBuffer) {
         throw new SignPdfError(
             `sign() is not implemented on ${this.constructor.name}`,
             SignPdfError.TYPE_INPUT,


### PR DESCRIPTION
At the moment the typings are wrong because the sign function is reported to be `sign(pdfBuffer: Buffer) => Buffer`. However, this is not a correct typing as the method is expected to return a promise as it is `async`. Therefore the typings should be `sign(pdfBuffer: Buffer) => Promise<Buffer>`.

Question - should we actually allow non `async` methods (as having it sometimes return a Promise and sometimes not is a bit of a confusing API to consume). I've changed the base implementation so it is no longer `async`, as this will be a bit more predictable for anyone that may be intercepting the sign method, but happy to revert that change.