### PR TITLE
[signpdf] export Signer and SignPdfError classes from utils

### DIFF
--- a/packages/signpdf/dist/signpdf.d.ts
+++ b/packages/signpdf/dist/signpdf.d.ts
@@ -21,4 +21,6 @@ export type SignerOptions = {
     asn1StrictParsing?: boolean;
 };
 import { Signer } from '@signpdf/utils';
+import { SignPdfError } from '@signpdf/utils';
+export { Signer, SignPdfError };
 //# sourceMappingURL=signpdf.d.ts.map

--- a/packages/signpdf/dist/signpdf.d.ts.map
+++ b/packages/signpdf/dist/signpdf.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"signpdf.d.ts","sourceRoot":"","sources":["../src/signpdf.js"],"names":[],"mappings":"AAQA;;;;GAIG;AAEH;IAEQ,mCAA0D;IAC1D,sBAAyB;IAG7B;;;;;OAKG;IACH,gBALW,MAAM,UACN,MAAM,GAEJ,QAAQ,MAAM,CAAC,CAwF3B;CACJ;;;;iBAvGS,MAAM;wBACN,OAAO;;uBALV,gBAAgB"}
+{"version":3,"file":"signpdf.d.ts","sourceRoot":"","sources":["../src/signpdf.js"],"names":[],"mappings":"AAUA;;;;GAIG;AAEH;IAEQ,mCAA0D;IAC1D,sBAAyB;IAG7B;;;;;OAKG;IACH,gBALW,MAAM,UACN,MAAM,GAEJ,QAAQ,MAAM,CAAC,CAwF3B;CACJ;;;;iBAvGS,MAAM;wBACN,OAAO;;uBAPV,gBAAgB;6BAAhB,gBAAgB"}

--- a/packages/signpdf/dist/signpdf.js
+++ b/packages/signpdf/dist/signpdf.js
@@ -3,7 +3,20 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.default = exports.SignPdf = void 0;
+exports.SignPdf = void 0;
+Object.defineProperty(exports, "SignPdfError", {
+  enumerable: true,
+  get: function () {
+    return _utils.SignPdfError;
+  }
+});
+Object.defineProperty(exports, "Signer", {
+  enumerable: true,
+  get: function () {
+    return _utils.Signer;
+  }
+});
+exports.default = void 0;
 var _utils = require("@signpdf/utils");
 /**
  * @typedef {object} SignerOptions

--- a/packages/signpdf/src/signpdf.js
+++ b/packages/signpdf/src/signpdf.js
@@ -6,6 +6,8 @@ import {
     Signer,
 } from '@signpdf/utils';
 
+export {Signer, SignPdfError};
+
 /**
  * @typedef {object} SignerOptions
  * @prop {string} [passphrase]


### PR DESCRIPTION
Consumers of the library may want to implement their own Signer or even catch and make assertions of errors. Exposing the classes from utils through this library means that consumers don't have to manually require the sub-package themselves, which helps avoid dependency resolution issues that can sometimes happen in npm when root projects and dependencies have slightly mis-matched version requirements.

In my view it's best for a package to export classes/interfaces/types it depends on (where possible) rather than have consumers import them manually through an explicit dependency definition.

eg: 

```js

const { sign, Signer } = require('@pdfsign/pdfsign');

```

is better than:

```js

const { sign } = require('@pdfsign/pdfsign');
const { Signer } = require('@pdfsign/utils');

```

I can give examples of npm's dependency issues that I've experienced when doing this kind of thing.