### PR TITLE
:green_heart: allow coveralls to run even if tests fail

### DIFF
--- a/.github/workflows/monorepo.yml
+++ b/.github/workflows/monorepo.yml
@@ -12,6 +12,7 @@ jobs:
       - run: ./node_modules/.bin/lerna run lint
       - run: ./node_modules/.bin/lerna run test -- --coverage
       - name: Coveralls (signpdf)
+        if: ${{ !cancelled() }}
         uses: coverallsapp/github-action@master
         with:
           parallel: true
@@ -20,6 +21,7 @@ jobs:
           base-path: packages/signpdf
           path-to-lcov: packages/signpdf/coverage/lcov.info
       - name: Coveralls (utils)
+        if: ${{ !cancelled() }}
         uses: coverallsapp/github-action@master
         with:
           parallel: true
@@ -28,6 +30,7 @@ jobs:
           base-path: packages/utils
           path-to-lcov: packages/utils/coverage/lcov.info
       - name: Coveralls (placeholder-pdfkit010)
+        if: ${{ !cancelled() }}
         uses: coverallsapp/github-action@master
         with:
           parallel: true
@@ -36,6 +39,7 @@ jobs:
           base-path: packages/placeholder-pdfkit010
           path-to-lcov: packages/placeholder-pdfkit010/coverage/lcov.info
       - name: Coveralls (placeholder-pdfkit)
+        if: ${{ !cancelled() }}
         uses: coverallsapp/github-action@master
         with:
           parallel: true
@@ -44,6 +48,7 @@ jobs:
           base-path: packages/placeholder-pdfkit
           path-to-lcov: packages/placeholder-pdfkit/coverage/lcov.info
       - name: Coveralls (placeholder-plain)
+        if: ${{ !cancelled() }}
         uses: coverallsapp/github-action@master
         with:
           parallel: true
@@ -52,6 +57,7 @@ jobs:
           base-path: packages/placeholder-plain
           path-to-lcov: packages/placeholder-plain/coverage/lcov.info
       - name: Coveralls (placeholder-pdf-lib)
+        if: ${{ !cancelled() }}
         uses: coverallsapp/github-action@master
         with:
           parallel: true
@@ -60,6 +66,7 @@ jobs:
           base-path: packages/placeholder-pdf-lib
           path-to-lcov: packages/placeholder-pdf-lib/coverage/lcov.info
       - name: Close Coveralls
+        if: ${{ !cancelled() }}
         uses: coverallsapp/github-action@master
         with:
           parallel-finished: true


### PR DESCRIPTION
I saw that the CI build on the last merge failed the code coverage minimum requirements, but this failure in the test step meant that the coveralls reports didn't get uploaded as the failure meant that part of the workflow was skipped.

This will allow the coveralls report to be uploaded unless the run is explicitly cancelled (which is the general recommendation in the [GitHub docs](https://docs.github.com/en/actions/learn-github-actions/expressions#always), rather than using `always`)