### PR TITLE
🐛 [placeholder-pdf-lib] Fix AcroForm Fields handling: create new array if missing and replace invalid fields

### DIFF
--- a/packages/placeholder-pdf-lib/src/pdflibAddPlaceholder.js
+++ b/packages/placeholder-pdf-lib/src/pdflibAddPlaceholder.js
@@ -167,6 +167,10 @@ export const pdflibAddPlaceholder = ({
         sigFlags.asNumber() | SIG_FLAGS.SIGNATURES_EXIST | SIG_FLAGS.APPEND_ONLY,
     );
     acroForm.set(PDFName.of('SigFlags'), updatedFlags);
-    const fields = acroForm.get(PDFName.of('Fields'));
+    let fields = acroForm.get(PDFName.of('Fields'));
+    if (!(fields instanceof PDFArray)) {
+        fields = doc.context.obj([]);
+        acroForm.set(PDFName.of('Fields'), fields);
+    }
     fields.push(widgetDictRef);
 };

--- a/packages/placeholder-pdf-lib/src/pdflibAddPlaceholder.test.js
+++ b/packages/placeholder-pdf-lib/src/pdflibAddPlaceholder.test.js
@@ -344,4 +344,43 @@ describe(pdflibAddPlaceholder, () => {
             PDFName.of(DEFAULT_BYTE_RANGE_PLACEHOLDER).asString(),
         ]);
     });
+    it('creates a new AcroForm Fields array when missing', async () => {
+        const input = readTestResource('w3dummy.pdf');
+        const pdfDoc = await PDFDocument.load(input);
+
+        const acroForm = pdfDoc.context.obj({});
+        const acroFormRef = pdfDoc.context.register(acroForm);
+        pdfDoc.catalog.set(PDFName.of('AcroForm'), acroFormRef);
+
+        pdflibAddPlaceholder({
+            pdfDoc,
+            ...defaults,
+        });
+
+        const finalAcroForm = pdfDoc.catalog.lookup(PDFName.of('AcroForm'), PDFDict);
+        const fields = finalAcroForm.lookup(PDFName.of('Fields'), PDFArray);
+
+        expect(fields).toBeInstanceOf(PDFArray);
+        expect(fields.size()).toBe(1);
+    });
+
+    it('replaces invalid AcroForm Fields with a new PDFArray', async () => {
+        const input = readTestResource('w3dummy.pdf');
+        const pdfDoc = await PDFDocument.load(input);
+
+        const acroForm = pdfDoc.context.obj({Fields: pdfDoc.context.obj({Invalid: true})});
+        const acroFormRef = pdfDoc.context.register(acroForm);
+        pdfDoc.catalog.set(PDFName.of('AcroForm'), acroFormRef);
+
+        pdflibAddPlaceholder({
+            pdfDoc,
+            ...defaults,
+        });
+
+        const finalAcroForm = pdfDoc.catalog.lookup(PDFName.of('AcroForm'), PDFDict);
+        const fields = finalAcroForm.lookup(PDFName.of('Fields'), PDFArray);
+
+        expect(fields).toBeInstanceOf(PDFArray);
+        expect(fields.size()).toBe(1);
+    });
 });


### PR DESCRIPTION
This PR solves this error:
`TypeError: Cannot read properties of undefined (reading 'push')`

This happened because pdf-lib returned a `PDFObject` which might be a `PDFArray` and might be a plain object with no `push` function.
In the context of adding a widget to the `Fields` object, it dosn't matter if there is none, one or many fields, we just want to add one(the widget).

So in this PR we ensure the creation of a new Fields array when missing and replace invalid Fields with a new PDFArray. This improves the handling of AcroForm Fields in the PDF library.

This PR solves the following issues:
#218 #247 #263 #275