### PR TITLE
🐛 extractSignature: read DER length instead of stripping trailing 00 pairs (fixes #317)

### DIFF
--- a/packages/utils/src/extractSignature.js
+++ b/packages/utils/src/extractSignature.js
@@ -11,6 +11,33 @@ const getSubstringIndex = (str, substring, n) => {
 
     return index;
 };
+
+/**
+ * Total encoded length (header + content) of the DER element starting at buf[0].
+ * Returns -1 if the buffer does not start with a parseable SEQUENCE header.
+ * @param {Buffer} buf
+ * @returns {number}
+ */
+const derTotalLength = (buf) => {
+    if (buf.length < 2 || buf[0] !== 0x30) {
+        return -1;
+    }
+    const lengthByte = buf[1];
+    if ((lengthByte & 0x80) === 0) {
+        // Short form: the byte is the content length itself.
+        return 2 + lengthByte;
+    }
+    const numLengthOctets = lengthByte & 0x7f;
+    if (numLengthOctets === 0 || buf.length < 2 + numLengthOctets) {
+        return -1;
+    }
+    let contentLength = 0;
+    for (let i = 0; i < numLengthOctets; i += 1) {
+        contentLength = contentLength * 256 + buf[2 + i];
+    }
+    return 2 + numLengthOctets + contentLength;
+};
+
 /**
  * Basic implementation of signature extraction.
  *
@@ -62,9 +89,21 @@ export const extractSignature = (pdf, signatureCount = 1) => {
 
     const signatureHex = pdf.slice(ByteRange[0] + ByteRange[1] + 1, ByteRange[2])
         .toString('binary')
-        .replace(/(?:00|>)+$/, '');
+        .replace(/(?:>|\s)+$/, '');
 
-    const signature = Buffer.from(signatureHex, 'hex').toString('binary');
+    // sign() right-pads the signature with zero bytes up to the placeholder
+    // length. DER is self-describing, so read the real element length from the
+    // SEQUENCE header instead of stripping trailing "00" pairs — a genuine
+    // signature has a ~1/256 chance of ending in 0x00 itself, and the old
+    // regex-based strip would eat those real bytes and corrupt the DER (#317).
+    const padded = Buffer.from(signatureHex, 'hex');
+    const totalLength = derTotalLength(padded);
+    const signatureBuffer = totalLength > 0 && totalLength <= padded.length
+        ? padded.slice(0, totalLength)
+        // Not parseable as DER — keep the historical trailing-zero strip.
+        : Buffer.from(signatureHex.replace(/(?:00)+$/, ''), 'hex');
+
+    const signature = signatureBuffer.toString('binary');
 
     return {
         ByteRange: matches.slice(1, 5).map(Number),

--- a/packages/utils/src/extractSignature.test.js
+++ b/packages/utils/src/extractSignature.test.js
@@ -43,4 +43,50 @@ describe(extractSignature, () => {
         const extracted = extractSignature(signedPdf);
         expect(extracted).toMatchSnapshot();
     });
+
+    /**
+     * Builds a minimal fake signed PDF: a self-consistent /ByteRange header,
+     * a /Contents-style <hex> placeholder holding derBuffer + zero padding,
+     * and a trailer.
+     */
+    const makeFakeSignedPdf = (derBuffer, paddingBytes) => {
+        const hex = derBuffer.toString('hex') + '00'.repeat(paddingBytes);
+        const placeholder = `<${hex}>`;
+        const trailer = 'trailer';
+        const pad = (n) => String(n).padStart(10, '0');
+        // Fixed-width numbers keep the header length independent of the values.
+        const prefix = '%PDF-1.7\n';
+        const headerFor = (b1, b2, b3) => `/ByteRange [0 ${pad(b1)} ${pad(b2)} ${pad(b3)}]`;
+        const b1 = prefix.length + headerFor(0, 0, 0).length; // offset of '<'
+        const b2 = b1 + placeholder.length; // just past '>'
+        const header = headerFor(b1, b2, trailer.length);
+        return Buffer.from(prefix + header + placeholder + trailer, 'binary');
+    };
+
+    it('keeps a genuine trailing 0x00 byte of the signature (#317)', () => {
+        // DER SEQUENCE whose real content ends in 0x00:
+        // 30 05 (SEQUENCE, len 5) 04 03 aa bb 00 (OCTET STRING, len 3)
+        const der = Buffer.from('30050403aabb00', 'hex');
+        const extracted = extractSignature(makeFakeSignedPdf(der, 20));
+        expect(Buffer.from(extracted.signature, 'binary')).toEqual(der);
+    });
+
+    it('trims placeholder padding from a long-form-length DER ending in 0x00', () => {
+        // SEQUENCE with long-form length: 30 82 01 06, then 262 content bytes
+        // (a 258-byte OCTET STRING incl. its 4-byte header) ending in 0x00.
+        const content = Buffer.concat([
+            Buffer.from('04820102', 'hex'),
+            Buffer.alloc(258, 0xab),
+        ]);
+        content[content.length - 1] = 0x00;
+        const der = Buffer.concat([Buffer.from('30820106', 'hex'), content]);
+        const extracted = extractSignature(makeFakeSignedPdf(der, 40));
+        expect(Buffer.from(extracted.signature, 'binary')).toEqual(der);
+    });
+
+    it('extracts an unpadded signature unchanged', () => {
+        const der = Buffer.from('30050403aabbcc', 'hex');
+        const extracted = extractSignature(makeFakeSignedPdf(der, 0));
+        expect(Buffer.from(extracted.signature, 'binary')).toEqual(der);
+    });
 });


### PR DESCRIPTION
## Problem

`extractSignature()` strips the placeholder padding with:

```js
.replace(/(?:00|>)+$/, '');
```

The regex cannot distinguish `sign()`'s zero-padding from a genuine signature whose last byte(s) happen to be `0x00`. A PKCS#7 `SignedData`'s final bytes are the raw RSA signature — effectively random — so ~1/256 signatures genuinely end in `0x00`. When one does, the strip eats real DER bytes and downstream parsers throw `Too few bytes to read ASN.1 value.` on a perfectly valid signature.

Full analysis in #317. We hit this as an intermittent (~0.4%) verification failure in CI; reproduced 9 truncations in 1500 sign/extract cycles against `@signpdf/utils` 3.x.

## Fix

DER is self-describing: read the total element length from the `SEQUENCE` header (short- and long-form lengths supported) and slice there — exactly the direction suggested in #317. If the blob does not parse as a DER `SEQUENCE`, fall back to the historical trailing-zero strip so non-DER edge cases keep their previous behavior.

Also, the slice-then-strip previously relied on the regex to remove the trailing `>`; the hex cleanup now strips only `>` and whitespace before decoding.

## Tests

- New: genuine trailing `0x00` byte is kept (short-form DER, the #317 scenario)
- New: long-form-length DER ending in `0x00` with padding is trimmed correctly
- New: unpadded signature is returned unchanged
- Existing `signed.pdf` snapshot unchanged; full monorepo `lerna run test` green (63/63 in utils)

🤖 Generated with [Claude Code](https://claude.com/claude-code)